### PR TITLE
Error Handling in `MainMenuScreen`

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -180,8 +180,8 @@ class MyApp extends StatelessWidget {
     required this.inAppPurchaseController,
     required this.adsController,
     required this.gamesServicesController,
-    Key? key,
-  }) : super(key: key);
+    super.key,
+  });
 
   @override
   Widget build(BuildContext context) {

--- a/lib/src/ads/banner_ad_widget.dart
+++ b/lib/src/ads/banner_ad_widget.dart
@@ -25,7 +25,7 @@ import 'package:tictactoe/src/ads/preloaded_banner_ad.dart';
 /// namely the `anchored_adaptive_example.dart` file:
 /// https://github.com/googleads/googleads-mobile-flutter/blob/main/packages/google_mobile_ads/example/lib/anchored_adaptive_example.dart
 class BannerAdWidget extends StatefulWidget {
-  const BannerAdWidget({Key? key}) : super(key: key);
+  const BannerAdWidget({super.key});
 
   @override
   State<BannerAdWidget> createState() => _BannerAdWidgetState();

--- a/lib/src/ai/random_opponent.dart
+++ b/lib/src/ai/random_opponent.dart
@@ -1,15 +1,14 @@
 import 'dart:math';
 
 import 'package:tictactoe/src/ai/ai_opponent.dart';
-import 'package:tictactoe/src/game_internals/board_setting.dart';
 import 'package:tictactoe/src/game_internals/board_state.dart';
 import 'package:tictactoe/src/game_internals/tile.dart';
 
 class RandomOpponent extends AiOpponent {
   const RandomOpponent(
-    BoardSetting setting, {
+    super.setting, {
     required this.name,
-  }) : super(setting);
+  });
 
   static final Random _random = Random();
 

--- a/lib/src/ai/scoring_opponent.dart
+++ b/lib/src/ai/scoring_opponent.dart
@@ -83,8 +83,7 @@ class ScoringOpponent extends AiOpponent {
 
 /// A scoring opponent that just cares about attacking.
 class AttackOnlyScoringOpponent extends ScoringOpponent {
-  AttackOnlyScoringOpponent(BoardSetting setting, {required String name})
-      : super(setting, name: name);
+  AttackOnlyScoringOpponent(super.setting, {required super.name});
 
   @override
   List<int> get _playerScoring => const [1, 1, 20, 90, 8000, 0];

--- a/lib/src/app_lifecycle/app_lifecycle.dart
+++ b/lib/src/app_lifecycle/app_lifecycle.dart
@@ -5,7 +5,7 @@ import 'package:provider/provider.dart';
 class AppLifecycleObserver extends StatefulWidget {
   final Widget child;
 
-  const AppLifecycleObserver({required this.child, Key? key}) : super(key: key);
+  const AppLifecycleObserver({required this.child, super.key});
 
   @override
   State<AppLifecycleObserver> createState() => _AppLifecycleObserverState();

--- a/lib/src/games_services/games_services.dart
+++ b/lib/src/games_services/games_services.dart
@@ -1,8 +1,10 @@
 import 'dart:async';
 
+import 'package:flutter/material.dart';
 import 'package:games_services/games_services.dart';
 import 'package:logging/logging.dart';
 import 'package:tictactoe/src/games_services/score.dart' as internal;
+import 'package:tictactoe/src/style/error_snackbar.dart';
 
 class GamesServicesController {
   static final Logger _log = Logger('GamesServicesController');
@@ -27,6 +29,13 @@ class GamesServicesController {
 
   void showAchievements() async {
     if (!await signedIn) {
+      showErrorSnackbar(
+        'sign in to view achivements',
+        action: SnackBarAction(
+          label: 'Sign in',
+          onPressed: initialize,
+        ),
+      );
       _log.severe('Trying to show achievements when not logged in.');
       return;
     }
@@ -40,6 +49,13 @@ class GamesServicesController {
 
   void showLeaderboard() async {
     if (!await signedIn) {
+      showErrorSnackbar(
+        'sign in to view leaderboard',
+        action: SnackBarAction(
+          label: 'Sign in',
+          onPressed: initialize,
+        ),
+      );
       _log.severe('Trying to show leaderboard when not logged in.');
       return;
     }

--- a/lib/src/level_selection/level_selection_screen.dart
+++ b/lib/src/level_selection/level_selection_screen.dart
@@ -9,7 +9,7 @@ import 'package:tictactoe/src/style/responsive_screen.dart';
 import 'package:tictactoe/src/style/rough/button.dart';
 
 class LevelSelectionScreen extends StatelessWidget {
-  const LevelSelectionScreen({Key? key}) : super(key: key);
+  const LevelSelectionScreen({super.key});
 
   @override
   Widget build(BuildContext context) {

--- a/lib/src/main_menu/main_menu_screen.dart
+++ b/lib/src/main_menu/main_menu_screen.dart
@@ -10,7 +10,7 @@ import 'package:tictactoe/src/style/responsive_screen.dart';
 import 'package:tictactoe/src/style/rough/button.dart';
 
 class MainMenuScreen extends StatelessWidget {
-  const MainMenuScreen({Key? key}) : super(key: key);
+  const MainMenuScreen({super.key});
 
   @override
   Widget build(BuildContext context) {

--- a/lib/src/play_session/board_tile.dart
+++ b/lib/src/play_session/board_tile.dart
@@ -10,7 +10,7 @@ import 'package:tictactoe/src/game_internals/tile.dart';
 import 'package:tictactoe/src/style/palette.dart';
 
 class BoardTile extends StatefulWidget {
-  const BoardTile(this.tile, {Key? key}) : super(key: key);
+  const BoardTile(this.tile, {super.key});
 
   /// The tile's position on the board.
   final Tile tile;

--- a/lib/src/play_session/game_board.dart
+++ b/lib/src/play_session/game_board.dart
@@ -7,8 +7,7 @@ import 'package:tictactoe/src/play_session/rough_grid.dart';
 class Board extends StatefulWidget {
   final VoidCallback? onPlayerWon;
 
-  const Board({Key? key, required this.setting, this.onPlayerWon})
-      : super(key: key);
+  const Board({super.key, required this.setting, this.onPlayerWon});
 
   final BoardSetting setting;
 

--- a/lib/src/play_session/play_session_screen.dart
+++ b/lib/src/play_session/play_session_screen.dart
@@ -27,7 +27,7 @@ import '../style/confetti.dart';
 class PlaySessionScreen extends StatefulWidget {
   final GameLevel level;
 
-  const PlaySessionScreen(this.level, {Key? key}) : super(key: key);
+  const PlaySessionScreen(this.level, {super.key});
 
   @override
   State<PlaySessionScreen> createState() => _PlaySessionScreenState();

--- a/lib/src/play_session/rough_grid.dart
+++ b/lib/src/play_session/rough_grid.dart
@@ -8,7 +8,7 @@ class RoughGrid extends StatelessWidget {
   final int width;
   final int height;
 
-  const RoughGrid(this.width, this.height, {Key? key}) : super(key: key);
+  const RoughGrid(this.width, this.height, {super.key});
 
   @override
   Widget build(BuildContext context) {

--- a/lib/src/settings/custom_name_dialog.dart
+++ b/lib/src/settings/custom_name_dialog.dart
@@ -17,7 +17,7 @@ void showCustomNameDialog(BuildContext context) {
 class CustomNameDialog extends StatefulWidget {
   final Animation<double> animation;
 
-  const CustomNameDialog({required this.animation, Key? key}) : super(key: key);
+  const CustomNameDialog({required this.animation, super.key});
 
   @override
   State<CustomNameDialog> createState() => _CustomNameDialogState();

--- a/lib/src/settings/settings_screen.dart
+++ b/lib/src/settings/settings_screen.dart
@@ -10,7 +10,7 @@ import 'package:tictactoe/src/style/responsive_screen.dart';
 import 'package:tictactoe/src/style/rough/button.dart';
 
 class SettingsScreen extends StatelessWidget {
-  const SettingsScreen({Key? key}) : super(key: key);
+  const SettingsScreen({super.key});
 
   static const _gap = SizedBox(height: 60);
 

--- a/lib/src/style/confetti.dart
+++ b/lib/src/style/confetti.dart
@@ -33,8 +33,8 @@ class Confetti extends StatefulWidget {
   const Confetti({
     this.colors = _defaultColors,
     this.isStopped = false,
-    Key? key,
-  }) : super(key: key);
+    super.key,
+  });
 
   @override
   State<Confetti> createState() => _ConfettiState();

--- a/lib/src/style/delayed_appear.dart
+++ b/lib/src/style/delayed_appear.dart
@@ -22,9 +22,8 @@ class DelayedAppear extends StatefulWidget {
     required int ms,
     this.delayStateCreation = false,
     this.onDelayFinished,
-    Key? key,
-  })  : delay = Duration(milliseconds: ms),
-        super(key: key);
+    super.key,
+  }) : delay = Duration(milliseconds: ms);
 
   @override
   State<DelayedAppear> createState() => _DelayedAppearState();

--- a/lib/src/style/error_snackbar.dart
+++ b/lib/src/style/error_snackbar.dart
@@ -1,0 +1,40 @@
+import 'package:flutter/material.dart';
+import 'package:tictactoe/src/style/palette.dart';
+import 'package:tictactoe/src/style/snack_bar.dart';
+
+void showErrorSnackbar(String errorMessage, {SnackBarAction? action}) {
+  final messenger = scaffoldMessengerKey.currentState;
+  final palette = Palette();
+  final text = RichText(
+    text: TextSpan(
+      children: [
+        TextSpan(
+          text: 'Error: ',
+          style: TextStyle(color: palette.redPen, fontWeight: FontWeight.bold),
+        ),
+        TextSpan(
+          text: errorMessage,
+          style: TextStyle(
+            color: palette.ink,
+          ),
+        ),
+      ],
+    ),
+  );
+
+  final duration = Duration(milliseconds: errorMessage.characters.length * 120);
+
+  messenger
+    ?..hideCurrentSnackBar()
+    ..showSnackBar(
+      SnackBar(
+        content: text,
+        margin: const EdgeInsets.only(bottom: 30, left: 24, right: 24),
+        behavior: SnackBarBehavior.floating,
+        duration: duration,
+        backgroundColor: palette.backgroundMain,
+        dismissDirection: DismissDirection.horizontal,
+        action: action,
+      ),
+    );
+}

--- a/lib/src/style/responsive_screen.dart
+++ b/lib/src/style/responsive_screen.dart
@@ -21,8 +21,8 @@ class ResponsiveScreen extends StatelessWidget {
     required this.rectangularMenuArea,
     this.topMessageArea = const SizedBox.shrink(),
     this.mainAreaProminence = 0.8,
-    Key? key,
-  }) : super(key: key);
+    super.key,
+  });
 
   @override
   Widget build(BuildContext context) {

--- a/lib/src/style/rough/button.dart
+++ b/lib/src/style/rough/button.dart
@@ -20,14 +20,14 @@ class RoughButton extends StatelessWidget {
   final SfxType soundEffect;
 
   const RoughButton({
-    Key? key,
+    super.key,
     required this.child,
     required this.onTap,
     this.textColor,
     this.fontSize = 32,
     this.drawRectangle = false,
     this.soundEffect = SfxType.buttonTap,
-  }) : super(key: key);
+  });
 
   void _handleTap(BuildContext context) {
     assert(onTap != null, "Don't call _handleTap when onTap is null");

--- a/lib/src/style/sprite.dart
+++ b/lib/src/style/sprite.dart
@@ -40,8 +40,8 @@ class AnimatedSprite extends AnimatedWidget {
     this.frameStart = 0,
     this.flipHorizontally = false,
     this.color,
-    Key? key,
-  }) : super(key: key, listenable: animation);
+    super.key,
+  }) : super(listenable: animation);
 
   @override
   Widget build(BuildContext context) {
@@ -73,8 +73,8 @@ class Sprite extends StatefulWidget {
     this.color,
     this.flipHorizontally = false,
     this.frame = 0,
-    Key? key,
-  }) : super(key: key);
+    super.key,
+  });
 
   @override
   State<Sprite> createState() => _SpriteState();

--- a/lib/src/win_game/win_game_screen.dart
+++ b/lib/src/win_game/win_game_screen.dart
@@ -13,9 +13,9 @@ class WinGameScreen extends StatelessWidget {
   final Score score;
 
   const WinGameScreen({
-    Key? key,
+    super.key,
     required this.score,
-  }) : super(key: key);
+  });
 
   @override
   Widget build(BuildContext context) {

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -715,5 +715,5 @@ packages:
     source: hosted
     version: "3.1.0"
 sdks:
-  dart: ">=2.17.0-206.0.dev <3.0.0"
+  dart: ">=2.17.0 <3.0.0"
   flutter: ">=2.8.1"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,7 +7,7 @@ publish_to: 'none'
 version: 1.7.8+35
 
 environment:
-  sdk: ">=2.16.0 <3.0.0"
+  sdk: ">=2.17.0 <3.0.0"
 
 dependencies:
   flutter:


### PR DESCRIPTION
if user did not sign in to `GamesServicesController` and if pressed on `Achievements` or `Leaderboard` button in `MainMenuScreen`

Before:
        - shows error in console
        - nothing shows in UI

After:
        - shows error in console
        - shows `Error snackBar` in UI